### PR TITLE
Button Layout, Reset Position, Personal Machine Config

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>electronic-leadscrew</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/els-f280049c/Configuration.h
+++ b/els-f280049c/Configuration.h
@@ -40,12 +40,11 @@
 //================================================================================
 
 // For Imperial leadscrews: pitch in Threads Per Inch (TPI)
-//#define LEADSCREW_TPI 12
+#define LEADSCREW_TPI 16
 
 // For metric leadscrews: pitch in hundredths of a millimeter (HMM)
 // Example: 200hmm = 2mm
-#define LEADSCREW_HMM 300
-
+//#define LEADSCREW_HMM 200
 
 
 
@@ -65,7 +64,7 @@
 
 // Steps and microsteps
 #define STEPPER_MICROSTEPS 8
-#define STEPPER_RESOLUTION 200
+#define STEPPER_RESOLUTION 600
 
 // Separate step and microstep settings for feed rates.  Redefine these if your
 // lathe has a separate feed drive train with a different ratio.
@@ -74,7 +73,7 @@
 
 // Step, direction and enable pins are normally active-high
 // #define INVERT_STEP_PIN true
-// #define INVERT_DIRECTION_PIN true
+#define INVERT_DIRECTION_PIN true
 #define INVERT_ENABLE_PIN true
 #define INVERT_ALARM_PIN true
 
@@ -94,7 +93,7 @@
 //================================================================================
 
 // Encoder resolution (counts per revolution)
-#define ENCODER_RESOLUTION 4000
+#define ENCODER_RESOLUTION 4096
 
 // Which encoder input to use
 #define ENCODER_USE_EQEP1

--- a/els-f280049c/ControlPanel.cpp
+++ b/els-f280049c/ControlPanel.cpp
@@ -280,6 +280,7 @@ bool ControlPanel :: isValidKeyState(KEY_REG testKeys) {
     switch(testKeys.all) {
     case 0:
     case 1 << 0:
+    case 1 << 1:
     case 1 << 2:
     case 1 << 3:
     case 1 << 4:

--- a/els-f280049c/ControlPanel.h
+++ b/els-f280049c/ControlPanel.h
@@ -102,14 +102,23 @@ typedef union LED_REG
 
 struct KEY_BITS
 {
+//    Uint16 UP:1;
+//    Uint16 reserved1:1;
+//    Uint16 DOWN:1;
+//    Uint16 IN_MM:1;
+//    Uint16 FEED_THREAD:1;
+//    Uint16 FWD_REV:1;
+//    Uint16 SET:1;
+//    Uint16 POWER:1;
     Uint16 UP:1;
-    Uint16 reserved1:1;
     Uint16 DOWN:1;
-    Uint16 IN_MM:1;
-    Uint16 FEED_THREAD:1;
+    Uint16 RPD_RIGHT:1;
+    Uint16 RPD_LEFT:1;
+    Uint16 MODE:1;
     Uint16 FWD_REV:1;
     Uint16 SET:1;
     Uint16 POWER:1;
+
 };
 
 typedef union KEY_REG


### PR DESCRIPTION
Added a menu option to reset the position reading to 0 degrees Changed how the buttons work. From right to left:
Power is now always able to be pressed. So you can stop the leadscrew while the spindle is running Settings: remains the same
Fwd/rev: remains the same
Feed/thead: combined with IN/mm into one mode button. Press to cycle between feed in mm, thread in mm, feed in inches, thread in inches In/MM: changed to a rapid left button,  not yet implemented -: changed to a rapid right button. Not yet implemented Extra button behind the control panel: changed to - +: remains the same

Right now I am debating on how/if to implement the rapid function. Current thoughts are that it requires a long press, slowly accelerates to a max speed, and stops when released